### PR TITLE
Typo: Correct key is "jasminrom" and not "jasmnrom"

### DIFF
--- a/oricutron.cfg
+++ b/oricutron.cfg
@@ -20,7 +20,7 @@
 ;mdiscrom = 'roms/microdis'
 
 ; Filename of the Jasmin ROM
-;jasmnrom = 'roms/jasmin'
+;jasminrom = 'roms/jasmin'
 
 ; Filename of the Pravetz 8D ROM
 ;pravetzrom = 'roms/pravetzt'


### PR DESCRIPTION
A typo error in the config file where the key for the jasmin ROM path is incorrect, the code search for jasminrom, the config provice "jasmnrom". 

I just corrected the default config file to use the correct name

(Thanks to _DBug_ for finding there were an issue when using non standard path for the jasmin rom)