### PR TITLE
Correct a compilation error against Visual Studio 2015 (windows.h mus…

### DIFF
--- a/render_gl.c
+++ b/render_gl.c
@@ -27,7 +27,12 @@
 
 #include "system.h"
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 #ifndef __APPLE__
+
 #include <GL/gl.h>
 #else
 #include <OpenGL/gl.h>


### PR DESCRIPTION
…t be include before GL.h). Works under Visual studio 2015/WIN10)