### PR TITLE
Improve CH376 emulation + add CREATE_DIR & ERASE_FILE support for Linux

### DIFF
--- a/plugins/ch376/ch376.c
+++ b/plugins/ch376/ch376.c
@@ -5,14 +5,16 @@
  * Code:                                                            *
  *   Jérôme 'Jede' Debrune                                          *
  *   Philippe 'OffseT' Rimauro                                      *
+ *   Christian 'Assinie' Lardière                                   *
  *                                                                  *
  ** ch376.c *********************************************************/
 
 /*
  Changes:
 
- 21.08.2017 - Jede  : Added support for CMD_DIR_CREATE and CMD_FILE_ERASE (WIN32 only)
- 22.07.2017 - OffseT: Added support for CMD_DIR_CREATE and CMD_FILE_ERASE (Added related Amiga system APIs only)
+ 05.10.2017 - Assinie: Added support for CMD_DIR_CREATE and CMD_FILE_ERASE (Linux only)
+ 21.08.2017 - Jede   : Added support for CMD_DIR_CREATE and CMD_FILE_ERASE (WIN32 only)
+ 22.07.2017 - OffseT : Added support for CMD_DIR_CREATE and CMD_FILE_ERASE (Added related Amiga system APIs only)
 
  */
 /* /// "Portable includes" */
@@ -46,6 +48,7 @@ extern struct Library *SysBase;
 #include <string.h>
 #include <sys/statvfs.h>
 #include <sys/stat.h>
+#include <errno.h>
 
 #else
 #error "FixMe!"
@@ -198,6 +201,8 @@ struct ch376
     CH376_FILE current_file;
     CH376_DIR current_directory_browsing;
 
+    CH376_BOOL current_file_is_directory;
+
     char *sdcard_drive_path;
     char *usb_drive_path;
 };
@@ -270,8 +275,11 @@ static CH376_S32 system_file_read(CH376_CONTEXT *context, CH376_FILE file, void 
 // Write some data into a file
 static CH376_S32 system_file_write(CH376_CONTEXT *context, CH376_FILE file, void *buffer, CH376_S32 size);
 
-// Delete a file (or a directory)
+// Delete a file
 static CH376_BOOL system_file_delete(CH376_CONTEXT *context, const char *file_name, CH376_LOCK root_lock);
+
+// Delete a directory
+static CH376_BOOL system_directory_delete(CH376_CONTEXT *context, CH376_LOCK root_lock);
 
 // Start examining a directory
 // Return information about the directory itself
@@ -522,6 +530,19 @@ static CH376_BOOL system_file_delete(CH376_CONTEXT *context, const char *file_na
     return (err != 0);
 }
 
+static CH376_BOOL system_directory_delete(CH376_CONTEXT *context, CH376_LOCK root_lock)
+{
+    // FIXME
+    struct Library *DOSBase = context->DOSBase;
+
+    dbg_printf("system_directory_delete: %s\n", root_lock));
+
+    if(root_lock)
+        return (DeleteFile(file_name) != 0);
+
+    return CH376_FALSE;
+}
+
 static CH376_DIR system_start_examine_directory(CH376_CONTEXT *context, CH376_LOCK dir_lock)
 {
     struct Library *DOSBase = context->DOSBase;
@@ -770,6 +791,15 @@ static CH376_BOOL system_file_delete(CH376_CONTEXT *context, const char *file_na
 	return (err != 0);
 }
 
+static CH376_BOOL system_directory_delete(CH376_CONTEXT *context, CH376_LOCK root_lock)
+{
+    dbg_printf("system_directory_delete: %s\n", root_lock));
+
+    if (root_lock)
+        return (RemoveDirectory(root_lock) != 0);
+
+    return CH376_FALSE;
+}
 
 static CH376_LOCK system_create_directory(CH376_CONTEXT *context, const char *dir_path, CH376_LOCK root_lock)
 {
@@ -930,12 +960,14 @@ static void * system_alloc_mem(int size)
 
 static void system_free_mem(void *ptr)
 {
-    free(ptr);
+    if (ptr)
+        free(ptr);
 }
 
 static CH376_BOOL system_init_context(CH376_CONTEXT *context, UNUSED void *user_data)
 {
   /* Nothing to do */
+    return CH376_TRUE;
 }
 
 static void system_clean_context(CH376_CONTEXT *context)
@@ -1009,7 +1041,10 @@ static CH376_LOCK system_obtain_directory_lock(CH376_CONTEXT *context, const cha
 
 static void system_release_directory_lock(CH376_CONTEXT *context, CH376_LOCK dir_lock)
 {
-    system_free_mem(dir_lock);
+    if(dir_lock != (CH376_LOCK)0)
+    {
+        system_free_mem(dir_lock);
+    }
 }
 
 static CH376_LOCK system_clone_directory_lock(CH376_CONTEXT *context, CH376_LOCK dir_lock)
@@ -1034,6 +1069,30 @@ static FILE * file_open(const char *file_name,  CH376_LOCK root_lock, const char
 
     if(old_dir)
     {
+        chdir(old_dir);
+        system_free_mem(old_dir);
+    }
+
+    return file;
+}
+
+static CH376_BOOL system_file_delete(CH376_CONTEXT *context, const char *file_name, CH376_LOCK root_lock)
+{
+    int err;
+    char *old_dir = NULL;
+
+    if(root_lock)
+    {
+        if((old_dir = getcwd(NULL, 0)) != NULL)
+            chdir(root_lock);
+    }
+
+    err = unlink(file_name);
+
+    dbg_printf("system_file_delete: %s\n", file_name);
+
+    if(old_dir)
+    {
         if(old_dir != NULL)
         {
             chdir(old_dir);
@@ -1041,22 +1100,71 @@ static FILE * file_open(const char *file_name,  CH376_LOCK root_lock, const char
         }
     }
 
-    return file;
+    return (err == 0);
+}
+
+static CH376_BOOL system_directory_delete(CH376_CONTEXT *context, CH376_LOCK root_lock)
+{
+    dbg_printf("system_directory_delete: %s\n", root_lock);
+
+    if (root_lock)
+        return (rmdir(root_lock) == 0);
+    else
+        return CH376_FALSE;
+}
+
+static CH376_LOCK system_create_directory(CH376_CONTEXT *context, const char *dir_path, CH376_LOCK root_lock)
+{
+    CH376_LOCK lock = NULL;
+    char *old_dir = NULL;
+
+    if(root_lock)
+    {
+        if((old_dir = getcwd(NULL, 0)) != NULL)
+            chdir(root_lock);
+    }
+
+    dbg_printf("system_create_directory: %s\n", dir_path);
+
+    if (!mkdir(dir_path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH))
+        lock = realpath(dir_path, NULL);
+
+    if(old_dir)
+    {
+        chdir(old_dir);
+        system_free_mem(old_dir);
+    }
+
+    return lock;
 }
 
 static CH376_FILE system_file_open_existing(CH376_CONTEXT *context, const char *file_name, CH376_LOCK root_lock)
 {
-    return file_open(file_name, root_lock, "wb+");
+    FILE *fp;
+    int err;
+
+    fp = file_open(file_name, root_lock, "rb+");
+    err= errno;
+
+    if (!fp)
+    {
+        if (err == EISDIR)
+        {
+            return file_open(file_name, root_lock, "rb");
+        }
+    }
+
+    return fp;
 }
 
 static CH376_FILE system_file_open_new(CH376_CONTEXT *context, const char *file_name, CH376_LOCK root_lock)
 {
-    return file_open(file_name, root_lock, "wb");
+    return file_open(file_name, root_lock, "wb+");
 }
 
 static void system_file_close(CH376_CONTEXT *context, CH376_FILE file)
 {
-    fclose(file);
+    if (file) fclose(file);
 }
 
 static CH376_S32 system_file_seek(CH376_CONTEXT *context, CH376_FILE file, int pos)
@@ -1074,7 +1182,7 @@ static CH376_S32 system_file_read(CH376_CONTEXT *context, CH376_FILE file, void 
     dbg_printf("system_file_read trying to read %d bytes\n", size);
 
     if(file)
-        return fread(buffer, size, 1, file);
+        return fread(buffer, 1, size, file);
     else
         return -1;
 }
@@ -1084,7 +1192,7 @@ static CH376_S32 system_file_write(CH376_CONTEXT *context, CH376_FILE file, void
     dbg_printf("system_file_write trying to write %d bytes\n", size);
 
     if(file)
-        return fwrite(buffer, size, 1, file);
+        return fwrite(buffer, 1, size, file);
     else
         return -1;
 }
@@ -1093,8 +1201,11 @@ static CH376_DIR system_start_examine_directory(CH376_CONTEXT *context, CH376_LO
 {
     CH376_DIR fib = system_alloc_mem(sizeof(struct _CH376_DIR));
 
-    fib->handle = opendir(dir_lock);
-    fib->entry = NULL;
+    if(fib)
+    {
+        fib->handle = opendir(dir_lock);
+        fib->entry = NULL;
+    }
 
     return fib;
 }
@@ -1102,13 +1213,19 @@ static CH376_DIR system_start_examine_directory(CH376_CONTEXT *context, CH376_LO
 static CH376_BOOL system_go_examine_directory(CH376_CONTEXT *context, CH376_LOCK dir_lock, CH376_DIR fib, struct FatDirInfo *dir_info)
 {
     CH376_BOOL is_done = CH376_FALSE;
+    struct stat file_stat;
+    char *old_dir = NULL;
 
-    if(fib) while((fib->entry = readdir(fib->handle)) && !is_done)
+    if(dir_lock)
+    {
+        if((old_dir = getcwd(NULL, 0)) != NULL)
+            chdir(dir_lock);
+    }
+
+    if(fib) while(!is_done && (fib->entry = readdir(fib->handle)))
     {
         if(normalize_file_name(fib->entry->d_name, dir_info->DIR_Name))
         {
-            struct stat file_stat;
-
             stat(fib->entry->d_name, &file_stat);
 
             dir_info->DIR_Attr = 0;
@@ -1145,13 +1262,22 @@ static CH376_BOOL system_go_examine_directory(CH376_CONTEXT *context, CH376_LOCK
         }
     }
 
+    if(old_dir)
+    {
+            chdir(old_dir);
+            system_free_mem(old_dir);
+    }
+
     return is_done;
 }
 
 static void system_finish_examine_directory(CH376_CONTEXT *context, CH376_DIR fib)
 {
-    closedir(fib->handle);
-    system_free_mem(fib);
+    if (fib)
+    {
+        closedir(fib->handle);
+        system_free_mem(fib);
+    }
 }
 
 /* /// */
@@ -1639,6 +1765,7 @@ void ch376_write_command_port(struct ch376 *ch376, CH376_U8 command)
                 // We are done
                 ch376->interface_status = 127; // Found :)
                 ch376->command_status = CH376_INT_SUCCESS;
+                ch376->current_file_is_directory = CH376_TRUE;
             }
             else
             {
@@ -1668,6 +1795,7 @@ void ch376_write_command_port(struct ch376 *ch376, CH376_U8 command)
 
                         system_release_directory_lock(&ch376->context, ch376->current_dir_lock);
                         ch376->current_dir_lock = current_dir_lock;
+                        ch376->current_file_is_directory = CH376_TRUE;
 
                         ch376->interface_status = 127; // Found :)
                         ch376->command_status = CH376_ERR_OPEN_DIR;
@@ -1684,6 +1812,7 @@ void ch376_write_command_port(struct ch376 *ch376, CH376_U8 command)
                         {
                             ch376->interface_status = 127; // Found :)
                             ch376->command_status = CH376_INT_SUCCESS;
+                            ch376->current_file_is_directory = CH376_FALSE;
                         }
                         else
                         {
@@ -1827,6 +1956,7 @@ void ch376_write_command_port(struct ch376 *ch376, CH376_U8 command)
         {
             char fixed_file_name[13]; // Max = 8 + '.' + 3 + '\0'
             int i = 0;
+            CH376_BOOL file_erased = CH376_FALSE;
 
             // back to root?
             if(ch376->cmd_data.CMD_FileName[i] == '/')
@@ -1837,15 +1967,23 @@ void ch376_write_command_port(struct ch376 *ch376, CH376_U8 command)
                 i++;
             }
 
-            trim_file_name(&ch376->cmd_data.CMD_FileName[i], fixed_file_name);
-
-            if(ch376->current_file)
+            if (ch376->cmd_data.CMD_FileName[i] != 0)
             {
-                system_file_close(&ch376->context, ch376->current_file);
-                ch376->current_file = (CH376_FILE)0;
+                trim_file_name(&ch376->cmd_data.CMD_FileName[i], fixed_file_name);
+
+                if(ch376->current_file)
+                {
+                    system_file_close(&ch376->context, ch376->current_file);
+                    ch376->current_file = (CH376_FILE)0;
+                }
+
+                if (ch376->current_file_is_directory)
+                    file_erased = system_directory_delete(&ch376->context, ch376->current_dir_lock);
+                else
+                    file_erased = system_file_delete(&ch376->context, fixed_file_name, ch376->current_dir_lock);
             }
 
-            if(system_file_delete(&ch376->context, fixed_file_name, ch376->root_dir_lock))
+            if (file_erased)
             {
                 dbg_printf("[WRITE][COMMAND][CH376_CMD_FILE_ERASE] file or directory deleted: %s\n", &ch376->cmd_data.CMD_FileName[i]);
 
@@ -2001,7 +2139,7 @@ void ch376_write_data_port(struct ch376 *ch376, CH376_U8 data)
         break;
 
     case CH376_CMD_SET_FILE_NAME:
-        dbg_printf("[WRITE][DATA][CH376_CMD_SET_FILE_NAME] got file name character \"%c\" (&%02x) for position %ld\n", data, data, ch376->pos_rw_in_cmd_data);
+        dbg_printf("[WRITE][DATA][CH376_CMD_SET_FILE_NAME] got file name character \"%c\" (&%02x) for position %d\n", data, data, ch376->pos_rw_in_cmd_data);
         // protect buffer overflow
         if(ch376->pos_rw_in_cmd_data < sizeof(ch376->cmd_data.CMD_FileName))
         {

--- a/plugins/ch376/ch376.c
+++ b/plugins/ch376/ch376.c
@@ -10,7 +10,7 @@
 
 /*
  Changes:
- 
+
  21.08.2017 - Jede  : Added support for CMD_DIR_CREATE and CMD_FILE_ERASE (WIN32 only)
  22.07.2017 - OffseT: Added support for CMD_DIR_CREATE and CMD_FILE_ERASE (Added related Amiga system APIs only)
 
@@ -337,12 +337,12 @@ static CH376_BOOL system_get_disk_info(CH376_CONTEXT *context, CH376_LOCK root_l
                 disk_info->DISK_TotalSector[0] = (total_sector & 0x000000ff) >>  0;
                 disk_info->DISK_TotalSector[1] = (total_sector & 0x0000ff00) >>  8;
                 disk_info->DISK_TotalSector[2] = (total_sector & 0x00ff0000) >> 16;
-                disk_info->DISK_TotalSector[3] = (total_sector & 0xff000000) >> 32;
+                disk_info->DISK_TotalSector[3] = (total_sector & 0xff000000) >> 24;
 
                 disk_info->DISK_FreeSector[0] = (free_sector & 0x000000ff) >>  0;
                 disk_info->DISK_FreeSector[1] = (free_sector & 0x0000ff00) >>  8;
                 disk_info->DISK_FreeSector[2] = (free_sector & 0x00ff0000) >> 16;
-                disk_info->DISK_FreeSector[3] = (free_sector & 0xff000000) >> 32;
+                disk_info->DISK_FreeSector[3] = (free_sector & 0xff000000) >> 24;
 
                 disk_info->DISK_DiskFat = 0x0c; // FAT32?
 
@@ -665,12 +665,12 @@ static CH376_BOOL system_get_disk_info(CH376_CONTEXT *context, CH376_LOCK root_l
         disk_info->DISK_TotalSector[0] = (INT8)((total_sector & 0x000000ff) >>  0);
         disk_info->DISK_TotalSector[1] = (INT8)((total_sector & 0x0000ff00) >>  8);
         disk_info->DISK_TotalSector[2] = (INT8)((total_sector & 0x00ff0000) >> 16);
-        disk_info->DISK_TotalSector[3] = (INT8)((total_sector & 0xff000000) >> 32);
+        disk_info->DISK_TotalSector[3] = (INT8)((total_sector & 0xff000000) >> 24);
 
         disk_info->DISK_FreeSector[0] = (INT8)((free_sector & 0x000000ff) >>  0);
         disk_info->DISK_FreeSector[1] = (INT8)((free_sector & 0x0000ff00) >>  8);
         disk_info->DISK_FreeSector[2] = (INT8)((free_sector & 0x00ff0000) >> 16);
-        disk_info->DISK_FreeSector[3] = (INT8)((free_sector & 0xff000000) >> 32);
+        disk_info->DISK_FreeSector[3] = (INT8)((free_sector & 0xff000000) >> 24);
 
         disk_info->DISK_DiskFat = 0x0c; // FAT32?
 
@@ -792,7 +792,7 @@ static CH376_LOCK system_create_directory(CH376_CONTEXT *context, const char *di
 	};
 
 	return root_lock; // instead of lock
-	
+
 }
 
 
@@ -959,12 +959,12 @@ static CH376_BOOL system_get_disk_info(CH376_CONTEXT *context, CH376_LOCK root_l
             disk_info->DISK_TotalSector[0] = (total_sector & 0x000000ff) >>  0;
             disk_info->DISK_TotalSector[1] = (total_sector & 0x0000ff00) >>  8;
             disk_info->DISK_TotalSector[2] = (total_sector & 0x00ff0000) >> 16;
-            disk_info->DISK_TotalSector[3] = (total_sector & 0xff000000) >> 32;
+            disk_info->DISK_TotalSector[3] = (total_sector & 0xff000000) >> 24;
 
             disk_info->DISK_FreeSector[0] = (free_sector & 0x000000ff) >>  0;
             disk_info->DISK_FreeSector[1] = (free_sector & 0x0000ff00) >>  8;
             disk_info->DISK_FreeSector[2] = (free_sector & 0x00ff0000) >> 16;
-            disk_info->DISK_FreeSector[3] = (free_sector & 0xff000000) >> 32;
+            disk_info->DISK_FreeSector[3] = (free_sector & 0xff000000) >> 24;
 
             disk_info->DISK_DiskFat = 0x0c; // FAT32?
 

--- a/plugins/ch376/ch376.c
+++ b/plugins/ch376/ch376.c
@@ -166,7 +166,7 @@ union CommandData
     struct FatDirInfo CMD_FatDirInfo;       // [R/O] CH376_CMD_FILE_OPEN, CH376_CMD_FILE_ENUM_GO
     struct DiskQuery  CMD_DiskQuery;        // [R/O] CH376_CMD_DISK_QUERY
     CH376_U8          CMD_FileSeek[4];      // [R/W] CH376_CMD_BYTE_LOCATE
-    CH376_U8          CMD_FileReadWrite[2]; // [W/O] CH376_CMD_BYTE_READ, CH376_CMD_BYTE_WRITE
+    CH376_U8          CMD_FileReadWrite[4]; // [W/O] CH376_CMD_BYTE_READ, CH376_CMD_BYTE_WRITE
     CH376_U8          CMD_IOBuffer[255];    // [R/W] CH376_CMD_BYTE_READ, CH376_CMD_BYTE_RD_GO, CH376_CMD_BYTE_WRITE, CH376_CMD_BYTE_WR_GO
     CH376_U8          CMD_CheckByte;        // [R/W] CH376_CMD_CHECK_EXIST
 };
@@ -2087,7 +2087,9 @@ void ch376_write_data_port(struct ch376 *ch376, CH376_U8 data)
             if(++ch376->pos_rw_in_cmd_data == sizeof(ch376->cmd_data.CMD_FileReadWrite))
             {
                 ch376->bytes_to_read_write = (ch376->cmd_data.CMD_FileReadWrite[0] <<  0)
-                                           | (ch376->cmd_data.CMD_FileReadWrite[1] <<  8);
+                                           | (ch376->cmd_data.CMD_FileReadWrite[1] <<  8)
+                                           | (ch376->cmd_data.CMD_FileReadWrite[2] << 16)
+                                           | (ch376->cmd_data.CMD_FileReadWrite[3] << 24);
                 file_read_chunk(ch376);
             }
         }
@@ -2102,7 +2104,9 @@ void ch376_write_data_port(struct ch376 *ch376, CH376_U8 data)
             if(++ch376->pos_rw_in_cmd_data == sizeof(ch376->cmd_data.CMD_FileReadWrite))
             {
                 ch376->bytes_to_read_write = (ch376->cmd_data.CMD_FileReadWrite[0] <<  0)
-                                           | (ch376->cmd_data.CMD_FileReadWrite[1] <<  8);
+                                           | (ch376->cmd_data.CMD_FileReadWrite[1] <<  8)
+                                           | (ch376->cmd_data.CMD_FileReadWrite[2] << 16)
+                                           | (ch376->cmd_data.CMD_FileReadWrite[3] << 24);
 
                 if(ch376->bytes_to_read_write > sizeof(ch376->cmd_data.CMD_IOBuffer))
                     ch376->nb_bytes_in_cmd_data = sizeof(ch376->cmd_data.CMD_IOBuffer);


### PR DESCRIPTION
Note: new system_directory_delete() function tested on Linux OS only