### PR TITLE
CH376: Add CMD_GET_FILE_SIZE support

### DIFF
--- a/plugins/ch376/ch376.c
+++ b/plugins/ch376/ch376.c
@@ -66,8 +66,8 @@ extern struct Library *SysBase;
 #define CH376_DATA_IC_VER 3
 
 // Commands
-#define CH376_CMD_NONE        0x00
-#define CH376_CMD_GET_IC_VER  0x01
+#define CH376_CMD_NONE          0x00
+#define CH376_CMD_GET_IC_VER    0x01
 #define CH376_CMD_CHECK_EXIST   0x06
 #define CH376_CMD_GET_FILE_SIZE 0x0c
 #define CH376_CMD_SET_USB_MODE  0x15

--- a/plugins/ch376/ch376.c
+++ b/plugins/ch376/ch376.c
@@ -633,6 +633,36 @@ static void system_finish_examine_directory(CH376_CONTEXT *context, CH376_DIR fi
     }
 }
 
+static CH376_S32 system_get_file_size(CH376_CONTEXT *context, CH376_FILE file)
+{
+    struct Library *DOSBase = context->DOSBase;
+    struct FileInfoBlock *fib = AllocDosObject(DOS_FIB, NULL);
+    CH376_S32 file_size = 0xffffffff;
+
+    if (fib)
+    {
+        if (file)
+        {
+            if ( ExamineFH(file, &fib) )
+            {
+                file_size = fib->fib_Size;
+            }
+            else
+            {
+               dbg_printf("system_get_file_size: error\n");
+            }
+        }
+        else
+        {
+            dbg_printf("system_get_file_size: no file handle\n");
+        }
+
+        FreeDosObject(DOS_FIB, fib);
+    }
+
+    return file_size;
+}
+
 /* /// */
 
 #elif defined(WIN32)
@@ -961,8 +991,6 @@ static void system_finish_examine_directory(CH376_CONTEXT *context, CH376_DIR fi
     }
 }
 
-#include <errno.h>
-#include <string.h>
 static CH376_S32 system_get_file_size(CH376_CONTEXT *context, CH376_FILE file)
 {
     CH376_S32 file_size = 0xffffffff;
@@ -977,8 +1005,7 @@ static CH376_S32 system_get_file_size(CH376_CONTEXT *context, CH376_FILE file)
         }
         else
         {
-           int err = errno;
-           dbg_printf("system_get_file_size: error (%s)\n", strerror(err));
+           dbg_printf("system_get_file_size: error\n");
         }
     }
     else
@@ -1317,8 +1344,6 @@ static void system_finish_examine_directory(CH376_CONTEXT *context, CH376_DIR fi
     }
 }
 
-#include <errno.h>
-#include <string.h>
 static CH376_S32 system_get_file_size(CH376_CONTEXT *context, CH376_FILE file)
 {
     CH376_S32 file_size = 0xffffffff;
@@ -1332,8 +1357,7 @@ static CH376_S32 system_get_file_size(CH376_CONTEXT *context, CH376_FILE file)
         }
         else
         {
-           int err = errno;
-           dbg_printf("system_get_file_size: error (%s)\n", strerror(err));
+           dbg_printf("system_get_file_size: error\n");
         }
     }
     else

--- a/plugins/ch376/ch376.c
+++ b/plugins/ch376/ch376.c
@@ -12,6 +12,7 @@
 /*
  Changes:
 
+ 07.12.2017 - Assinie: Added support for CMD_GET_FILE_SIZE
  06.12.2017 - Assinie: Added support for CMD_DISK_CAPACITY
  13.11.2017 - Assinie: Improve '*' wildcard support for CMD_FILE_OPEN
  05.10.2017 - Assinie: Added support for CMD_DIR_CREATE and CMD_FILE_ERASE (Linux only)

--- a/plugins/ch376/ch376.c
+++ b/plugins/ch376/ch376.c
@@ -961,6 +961,32 @@ static void system_finish_examine_directory(CH376_CONTEXT *context, CH376_DIR fi
     }
 }
 
+#include <errno.h>
+#include <string.h>
+static CH376_S32 system_get_file_size(CH376_CONTEXT *context, CH376_FILE file)
+{
+    CH376_S32 file_size = 0xffffffff;
+    BY_HANDLE_FILE_INFORMATION file_stat;
+
+    if (file)
+    {
+        if ( GetFileInformationByHandle(file, &file_stat) )
+        {
+            // Only low DWORD
+            file_size = file_stat.nFileSizeLow;
+        }
+        else
+        {
+           int err = errno;
+           dbg_printf("system_get_file_size: error (%s)\n", strerror(err));
+        }
+    }
+    else
+        dbg_printf("system_get_file_size: no file handle\n");
+
+    return file_size;
+}
+
 /* /// */
 
 #elif defined(__unix__)


### PR DESCRIPTION
Tested under Linux & Windows only.
Need to be tested under MorphOS.