### PR TITLE
Bug Fix in load_snapshot()

### DIFF
--- a/snapshot.c
+++ b/snapshot.c
@@ -801,7 +801,7 @@ SDL_bool load_snapshot(struct machine *oric, char *filename)
   }
 
   /* Get the main block */
-  blk = load_block(oric, "OSN\x00", f, SDL_TRUE, 20, SDL_TRUE);
+  blk = load_block(oric, "OSN\x00", f, SDL_TRUE, 21, SDL_TRUE);
   if (!blk)
   {
     free_blockheaders();


### PR DESCRIPTION
Fix bug introduced in commit https://github.com/pete-gordon/oricutron/commit/24b3a4bf43f261543fd262e67e635643584d09b8 which prevent Oricutron from loading snapshot file.

oric->sync modified from U8 to U16 on line https://github.com/pete-gordon/oricutron/blob/master/snapshot.c#L174 in commit https://github.com/pete-gordon/oricutron/commit/24b3a4bf43f261543fd262e67e635643584d09b8 but line https://github.com/pete-gordon/oricutron/blob/master/snapshot.c#L804 not modified accordingly.