### PR TITLE
Snapshot bug - Take 2

### DIFF
--- a/snapshot.c
+++ b/snapshot.c
@@ -801,7 +801,7 @@ SDL_bool load_snapshot(struct machine *oric, char *filename)
   }
 
   /* Get the main block */
-  blk = load_block(oric, "OSN\x00", f, SDL_TRUE, 20, SDL_TRUE);
+  blk = load_block(oric, "OSN\x00", f, SDL_TRUE, 21, SDL_TRUE);
   if (!blk)
   {
     free_blockheaders();

--- a/snapshot.c
+++ b/snapshot.c
@@ -811,7 +811,7 @@ SDL_bool load_snapshot(struct machine *oric, char *filename)
 
   /* Set up the emulation for the required machine type */
   type      = blk->buf[0];
-  drivetype = blk->buf[13];
+  drivetype = blk->buf[14];
 
   if (type >= MACH_LAST)
   {


### PR DESCRIPTION
Bad offset for drivetype.

There is something else not fixed here: when Oricutron is started from command line with a snapshot file  as parameter, the emulated Oric is restarted but not when the snapshot is loaded from the monitor or the gui.

I think the Oric should not be restarted in all cases.