### PR TITLE
Fix .gitignore not applying to VS2017 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,18 @@
-/msvc/.vs
-Debug
-Release
-x64
+msvc/**/.vs/
+Debug/
+Release/
+x64/
 *.d
 *.o
-/msvc/Debug clang
-/msvc/Release clang
-/msvc/images
-/msvc/oricutron.cfg
-/msvc/roms
-/msvc/sdl
-/msvc/sdl2
+/msvc/**/Debug clang
+/msvc/**/Release clang
+/msvc/**/images
+/msvc/**/oricutron.cfg
+/msvc/**/roms
+/msvc/**/sdl
+/msvc/**/sdl2
 /roms/*.rom
 !/roms/orix*.rom
 /oricutron.aps
-/msvc/Oricutron.psess
-/msvc/Oricutron.vcxproj.user
+/msvc/**/Oricutron.psess
+/msvc/**/*.user


### PR DESCRIPTION
The `.gitignore` entries for MSVC files were only valid for VS2015. This change allows subdirectories at any level within `msvc` to also be targeted by the ignore entries.

The trailing slashes allow ignoring directories only.