### PR TITLE
Fix SDL2 audio output

### DIFF
--- a/8912.h
+++ b/8912.h
@@ -103,6 +103,8 @@ struct ay8912
   struct tnchange tapelog[TAPELOG_SIZE];
 };
 
+extern SDL_AudioCVT cvt;
+
 void queuekeys( char *str );
 
 SDL_bool ay_init( struct ay8912 *ay, struct machine *oric );


### PR DESCRIPTION
This converts audio on the fly during callback when using SDL2 only. The issue with the current version is that SDL2 does not honor the requested audio parameters, so when the callback function writes into the stream, the format that Oricutron assumes is being used is not actually correct (or not necessarily).