### PR TITLE
Recenter the window when exiting fullscreen mode

### DIFF
--- a/system_sdl.c
+++ b/system_sdl.c
@@ -377,6 +377,12 @@ SDL_Surface* SDL_COMPAT_SetVideoMode(int width, int height, int bitsperpixel, Ui
 
   FreeResources();
 
+  // When leaving fullscreen mode, X and Y coordinates should be recentered relative to the display.
+  if (flags ^ SDL_WINDOW_FULLSCREEN) {
+      g_lastx = SDL_WINDOWPOS_CENTERED;
+      g_lasty = SDL_WINDOWPOS_CENTERED;
+  }
+
   g_window = SDL_CreateWindow("oricutron", g_lastx, g_lasty,
                               g_width, g_height, flags);
   if (g_icon)


### PR DESCRIPTION
This moves the window back to the center of the display
instead of to (0, 0) when exiting fullscreen mode, which
has the side effect of hiding the title bar if it is present.

As far as I can tell, Oricutron is meant to remember the coordinates of the window when entering fullscreen mode, and restore the window to those coordinates after exiting it. However it doesn't seem to be fully implemented and as a result, the window is placed at (0, 0). Instead of outright removing the mechanism to save the coordinates, this adds an extra bit of logic that could be removed later if the desired functionality is fully implemented.