### PR TITLE
Bugfix: CA1 raised but never lowered when printing filtered characters

### DIFF
--- a/via.c
+++ b/via.c
@@ -67,12 +67,12 @@ void lprintchar( struct machine *oric, char c )
 
       // Put the char to the file, set up the timers
       fputc( c, oric->prf );
-      oric->prclock = 40;
       oric->prclose = 64*312*50*5;
     }
-    // emulate ack signal
-    via_write_CA1( &oric->via, 1 );
   }
+  // emulate ack signal
+  oric->prclock = 40;
+  via_write_CA1( &oric->via, 1 );
 }
 
 


### PR DESCRIPTION
If you try to print a filtered character, the Acknoledge bit is raised but can't be lowered because the prclock timer is 0 in this case/

**Bug evidence:** (note the **;** at the end of the line)
```LPRINT CHR$(254);```

Same issue if you try to **LPRINT** something after you **CLOAD** a program (probably related to the reconfiguration of the VIA by the K7 routines in the ROM).

I moved the _"emulate ack signal"_ block to the end of the function because this signal must always be emulated even if the **printenable** flag is false.
