### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,13 @@ endif (UNIX)
 
 include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
-if (WIN32)
-  "${PROJECT_SOURCE_DIR}/msvc"
-endif (WIN32)
 )
+
+if (WIN32)
+include_directories(
+  "${PROJECT_SOURCE_DIR}/msvc"
+)
+endif (WIN32)
 
 SET (SRCAMIGA
   filereq_amiga.c


### PR DESCRIPTION
Fix: compiling on Raspbian Buster (10) did not work because of WIN32 include_directories