### PR TITLE
Fix decimal mode

### DIFF
--- a/6502.c
+++ b/6502.c
@@ -110,14 +110,16 @@ void m6502_reset( struct m6502 *cpu )
 // Macro to perform ADC logic
 #define DO_ADC if( cpu->f_d )\
                {\
+                 r = cpu->a + v + cpu->f_c;\
+                 cpu->f_z = (r & 0xff)==0;\
                  r = (cpu->a&0xf)+(v&0xf)+cpu->f_c;\
-                 if( r > 9 ) r += 6;\
-                 t = (cpu->a>>4)+(v>>4)+(r>15?1:0);\
-                 if( t > 9 ) t += 6;\
-                 cpu->a = (r&0xf)|(t<<4);\
-                 cpu->f_c = t>15 ? 1 : 0;\
-                 cpu->f_z = cpu->a==0;\
-                 cpu->f_n = cpu->a&0x80;\
+                 if( r > 9 ) r = ((r+6)& 0xf)+0x10;\
+                 t = (cpu->a & 0xf0)+(v & 0xf0)+r;\
+                 cpu->f_v = (~(cpu->a^v)&(cpu->a^t)) & FF_N ? 1 : 0;\
+                 cpu->f_n = (t&0x80) ? 1 : 0;\
+                 if (t >= 0xa0) t += 0x60;\
+                 cpu->a = t;\
+                 cpu->f_c = t>=0x100 ? 1 : 0;\
                } else {\
                  r = cpu->a + v + cpu->f_c;\
                  cpu->f_v = (~(cpu->a^v)&(cpu->a^r)) & FF_N ? 1 : 0;\


### PR DESCRIPTION
When D flag is set, calculation result and flags for ADC and SBC instructions are incorrect even for valid BCD values.

This patch fix SBC and ADC instructions when D flag is set.
Verified with Klaus Dormann decimal test: https://github.com/Klaus2m5/6502_65C02_functional_tests/blob/master/6502_decimal_test.a65