### PR TITLE
disk: improve ID mark search

### DIFF
--- a/disk.c
+++ b/disk.c
@@ -240,7 +240,8 @@ void diskimage_cachetrack( struct diskimage *dimg, int track, int side )
   while( ptr < eot )
   {
     // Search for ID mark
-    while( (ptr<eot) && (ptr[0]!=0xfe) ) ptr++;
+    while( (ptr<eot) && !((ptr[0]==0xa1) && (ptr[1]==0xa1) && (ptr[2]==0xa1) && (ptr[3]==0xfe)) ) ptr++;
+    ptr += 3;
 
     // Don't exceed the bounds of this track
     if( ptr >= eot ) break;

--- a/disk.c
+++ b/disk.c
@@ -240,7 +240,7 @@ void diskimage_cachetrack( struct diskimage *dimg, int track, int side )
   while( ptr < eot )
   {
     // Search for ID mark
-    while( (ptr<eot) && !((ptr[0]==0xa1) && (ptr[1]==0xa1) && (ptr[2]==0xa1) && (ptr[3]==0xfe)) ) ptr++;
+    while( ((ptr+3)<eot) && !((ptr[0]==0xa1) && (ptr[1]==0xa1) && (ptr[2]==0xa1) && (ptr[3]==0xfe)) ) ptr++;
     ptr += 3;
 
     // Don't exceed the bounds of this track


### PR DESCRIPTION
Quick patch to improve track scan.
Search for $A1 $A1 $A1 $FE instead of just $FE to find the beginning of a sector.
See discussion here https://forum.defence-force.org/viewtopic.php?f=8&t=2248