### PR TITLE
Add monitor memory search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,19 +40,21 @@ if (WIN32)
 endif (WIN32)
 
 if (UNIX)
-  # Use the package PkgConfig to detect GTK+ headers/library files
-  find_package(PkgConfig REQUIRED)
-  PKG_CHECK_MODULES(GTK3 REQUIRED gtk+-3.0)
 
   if (USE_SDL2)
     find_package(SDL2 REQUIRED)
-
+    find_package(OpenGL)
     # Setup CMake to use GTK+ and SDL2, tell the compiler where to look for headers
     # and to the linker where to look for libraries
     include_directories(${GTK3_INCLUDE_DIRS} ${SDL2_INCLUDE_DIRS})
-    link_directories(${GTK3_LIBRARY_DIRS})
+    if (OPENGL_FOUND)
+      add_definitions(-D__OPENGL_AVAILABLE__)
+    endif(OPENGL_FOUND)
     add_definitions(${GTK3_CFLAGS_OTHER} -DSDL_MAJOR_VERSION=2 -D__SPECIFY_SDL_DIR__=1 -DAPP_NAME_FULL="${ORICUTRON_APPNAME_FULL}" -DAPP_YEAR="${ORICUTRON_APPYEAR}" -DVERSION_COPYRIGHTS="${ORICUTRON_VERSION_COPYRIGHTS}")
   else()
+    # Use the package PkgConfig to detect GTK+ headers/library files
+    find_package(PkgConfig REQUIRED)
+    PKG_CHECK_MODULES(GTK3 REQUIRED gtk+-3.0)
     find_package(SDL REQUIRED)
 
     # Setup CMake to use GTK+ and SDL, tell the compiler where to look for headers
@@ -92,8 +94,10 @@ SET (SRCGTK
 
 SET (SRCSDL
   filereq_sdl.c
+  gui_x11.c
   msgbox_sdl.c
 )
+
 
 SET (SRCSWIN
   filereq_win32.c
@@ -146,8 +150,8 @@ endif (WIN32)
 
 if (UNIX)
   if (USE_SDL2)
-    add_executable(Oricutron-sdl2 ${SRCS} ${SRCGTK})
-    target_link_libraries(Oricutron-sdl2 ${GTK3_LIBRARIES} ${SDL2_LIBRARIES})
+    add_executable(Oricutron-sdl2 ${SRCS} ${SRCSDL})
+    target_link_libraries(Oricutron-sdl2 ${OPENGL_LIBRARIES} ${SDL2_LIBRARIES})
   else()
     add_executable(Oricutron ${SRCS} ${SRCGTK})
     target_link_libraries(Oricutron ${GTK3_LIBRARIES} SDL GL X11)

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -37,6 +37,7 @@ Credits
   Kamel Biskri
   Iss
   Christian from defence-force forum
+  Cedric Paille
 
 
   Amiga & Windows ports
@@ -298,6 +299,9 @@ Commands:
   m <addr>              - Dump memory
   mm <addr> <value>     - Modify memory
   mw <addr>             - Memory watch at addr
+  ms <value>            - Search value in RAM memory
+  mr <value>            - Refine search with new value
+  mp                    - Print memory search addresses
   nl <file>             - Load snapshot
   ns <file>             - Save snapshot
   r <reg> <val>         - Set <reg> to <val>

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -301,7 +301,7 @@ Commands:
   mw <addr>             - Memory watch at addr
   ms <value>            - Search value in RAM memory
   mr <value>            - Refine search with new value
-  mp                    - Print memory search addresses
+  p                     - Print memory search addresses
   nl <file>             - Load snapshot
   ns <file>             - Save snapshot
   r <reg> <val>         - Set <reg> to <val>

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -301,7 +301,7 @@ Commands:
   mw <addr>             - Memory watch at addr
   ms <value>            - Search value in RAM memory
   mr <value>            - Refine search with new value
-  p                     - Print memory search addresses
+  mp                    - Print memory search addresses
   nl <file>             - Load snapshot
   ns <file>             - Save snapshot
   r <reg> <val>         - Set <reg> to <val>

--- a/monitor.c
+++ b/monitor.c
@@ -111,7 +111,7 @@ static struct via via2_old;
 static SDL_bool via2_oldvalid = SDL_FALSE;
 static SDL_bool modified = SDL_FALSE;
 
-static uint16_t memory_search[0x92ff];
+static uint16_t memory_search[0x9800-0x0500];
 static int memory_hits= 0;
 //                                                             12345678901       12345678
 static struct msym defsym_tele[]  = { { 0x0300, 0,            "VIA_IORB"      , "VIA_IORB"   , "VIA_IORB" },
@@ -2941,41 +2941,6 @@ SDL_bool mon_cmd( char *cmd, struct machine *oric, SDL_bool *needrender )
       }
       break;
 
-    case 'p':
-    {
-      lastcmd = cmd[i];
-      i++;
-
-      int lines = 0;
-      char tmp[16];
-      int j, k = 0;
-
-      vsptmp[0] = 0;
-      for (j = memory_search_pos; j < memory_hits; j++, k++){
-        unsigned char byte = mon_read( oric, memory_search[j] );
-        sprintf( tmp, "[%04X]:[%02X] ", memory_search[j], byte );
-        strcat( vsptmp, tmp );
-        if (k == 4){
-          mon_str( vsptmp );
-          vsptmp[0] = 0;
-          lines++;
-          k = 0;
-        }
-        if (lines > 16){
-            memory_search_pos = j;
-            break;
-        }
-      }
-      if (strlen( vsptmp )){
-        mon_str( vsptmp );
-      }
-      if ( j >= memory_hits ){
-        memory_search_pos = 0;
-        lastcmd = 0;
-      }
-      break;
-    }
-
     case 'm':
       lastcmd = cmd[i];
       i++;
@@ -3029,6 +2994,41 @@ SDL_bool mon_cmd( char *cmd, struct machine *oric, SDL_bool *needrender )
           sprintf( vsptmp, "Refined match(es) : %i", memory_hits );
           mon_str( vsptmp );
           break;
+
+        case 'p':
+        {
+          lastcmd = 0;
+
+          int lines = 0;
+          char tmp[16];
+          int j, k = 0;
+
+          vsptmp[0] = 0;
+          for (j = memory_search_pos; j < memory_hits; j++, k++){
+            unsigned char byte = mon_read( oric, memory_search[j] );
+            sprintf( tmp, "[%04X]:[%02X] ", memory_search[j], byte );
+            strcat( vsptmp, tmp );
+            if (k == 4){
+              mon_str( vsptmp );
+              vsptmp[0] = 0;
+              lines++;
+              k = 0;
+            }
+            if (lines > 16){
+                memory_search_pos = j;
+                break;
+            }
+          }
+          if (strlen( vsptmp )){
+            mon_str( vsptmp );
+          }
+          if ( j >= memory_hits ){
+            memory_search_pos = 0;
+            lastcmd = 0;
+          }
+          break;
+        }
+
         case 'm':
           lastcmd = 0;
           i++;
@@ -3413,7 +3413,7 @@ SDL_bool mon_cmd( char *cmd, struct machine *oric, SDL_bool *needrender )
           mon_str( "  mw <addr>             - Memory watch at addr" );
           mon_str( "  ms <addr> <value>     - Memory search" );
           mon_str( "  mr <addr>             - Memory search refine" );
-          mon_str( "  p <addr>              - Memory print search" );
+          mon_str( "  mp                    - Memory print search" );
           mon_str( "  nl <filename>         - Load snapshot" );
           mon_str( "  ns <filename>         - Save snapshot" );
           mon_str( "  r <reg> <val>         - Set <reg> to <val>" );
@@ -3961,7 +3961,6 @@ static SDL_bool mon_console_keydown( SDL_Event *ev, struct machine *oric, SDL_bo
           case '?':
           case 'm':
           case 'd':
-          case 'p':
             ibuf[cursx++] = lastcmd;
             ibuf[cursx] = 0;
             ilen = 1;

--- a/monitor.c
+++ b/monitor.c
@@ -3381,11 +3381,12 @@ SDL_bool mon_cmd( char *cmd, struct machine *oric, SDL_bool *needrender )
           mon_str( "  m <addr>              - Dump memory" );
           mon_str( "  mm <addr> <value>     - Modify memory" );
           mon_str( "  mw <addr>             - Memory watch at addr" );
+          mon_str( "  ms <addr> <value>     - Memory search" );
+          mon_str( "  mr <addr>             - Memory search refine" );
+          mon_str( "  mp <addr>             - Memory print search" );
           mon_str( "  nl <filename>         - Load snapshot" );
           mon_str( "  ns <filename>         - Save snapshot" );
           mon_str( "  r <reg> <val>         - Set <reg> to <val>" );
-          mon_str( "  q, x or qm            - Quit monitor" );
-          mon_str( "  qe                    - Quit emulator" );
           mon_str( "  sa <name> <addr>      - Add or move user sym." );
           mon_str( "  sk <name>             - Kill user symbol" );
           mon_str( "  sc                    - Symbols not case-sens." );
@@ -3394,18 +3395,16 @@ SDL_bool mon_cmd( char *cmd, struct machine *oric, SDL_bool *needrender )
           mon_str( "  sx <file>             - Export user symbols" );
           mon_str( "  sz                    - Zap user symbols" );
           mon_str( " " );
-          mon_str( " " );
           mon_str( "---- MORE" );
           helpcount++;
           break;
 
         case 2:
-          mon_str( "  fd <addr> <end> <file>- Disassemble to file" );
+          mon_str( "  q, x or qm            - Quit monitor" );
+          mon_str( "  qe                    - Quit emulator" );          mon_str( "  fd <addr> <end> <file>- Disassemble to file" );
           mon_str( "  fw <addr> <len> <file>- Write mem to bin file" );
 // ToDo:  mon_str( "  ft <addr> <len> <file>- Write mem to tap file" );
           mon_str( "  fr <addr> <file>      - Read bin file to mem" );
-          mon_str( " " );
-          mon_str( " " );
           mon_str( " " );
           mon_str( " " );
           mon_str( " " );


### PR DESCRIPTION
Hi,
I added a memory search functionnality. I did it to hack some games and finally finish them !
Here's a quick doc : 
- launch the game and check for lives number
- launch monitor (F2) execute **ms <lives#>**
- return to game
- die
- relaunch monitor and execute **mr <lives#-1>**
- show memory addresses with **p** command

At this point you should get one or more memory match (refine more if necessary)
now you should know where the lives counter is in memory, just do a **mm <memory_address> <new lives#>** to set new lives number and you're done.

new commands : 
- ms [memory search]
- mr [memory search refine]
- p [print found memory locations]

The search is made in free ram (0x500-0x97FF)

Hope you'll like it :)
