### PR TITLE
Fix linker error when building with sdl2 on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ LFLAGS += $(CROSS_LFLAGS) -s
 else
 LFLAGS += $(shell $(SDL_LIB)-config --libs) -s
 endif
-LFLAGS += -lm -Wl,-framework,OpenGL
+LFLAGS += -lm -Wl,-framework,OpenGL -Wl,-framework,Cocoa
 TARGET = $(TARGET_NAME)
 FILEREQ_OBJ =
 MSGBOX_OBJ =


### PR DESCRIPTION
This fixes a build error I encountered on macOS Sonoma with homebrew sdl2.
The fix is to link against Cocoa framework.
With the fix I can build using "make SDL_LIB=sdl2".