### PR TITLE
Fix black screen with the OpenGL renderer on Linux (Wayland/XWayland)

### DIFF
--- a/system_sdl.c
+++ b/system_sdl.c
@@ -505,8 +505,15 @@ SDL_Surface* SDL_COMPAT_SetVideoMode(int width, int height, int bitsperpixel, Ui
 
   if(flags & SDL_WINDOW_OPENGL)
   {
-    g_screen = SDL_GetWindowSurface(g_window);
+    /* In SDL2 a window is backed by EITHER a window framebuffer
+       (SDL_GetWindowSurface/SDL_UpdateWindowSurface) OR an OpenGL drawable
+       (SDL_GL_SwapWindow), never both. Calling SDL_GetWindowSurface() here put
+       the window into framebuffer-presentation mode, so the GL back buffer was
+       never shown (black window under Mesa/XWayland on Ubuntu 24.04).
+       In GL mode g_screen is only used as a non-NULL "success" sentinel, so we
+       create a tiny dummy surface instead of grabbing the window surface. */
     g_glcontext = SDL_GL_CreateContext(g_window);
+    g_screen = SDL_CreateRGBSurface(0, 1, 1, g_bpp, RMASK, GMASK, BMASK, AMASK);
 
     SDL_GL_SetSwapInterval(1);
   }


### PR DESCRIPTION
On Ubuntu 24.04 (Wayland), starting Oricutron with `rendermode = opengl`
gives a completely black window. The emulator itself runs fine (sound,
keyboard, everything works), but nothing is ever drawn. Software rendering
works without any problem.

The cause is in `system_sdl.c`: for an OpenGL window we call
`SDL_GetWindowSurface()`, which switches the window into framebuffer mode.
After that, `SDL_GL_SwapWindow()` never shows anything, so the window stays
black. This seems to have been harmless on older SDL2/X11 setups but breaks
on current Mesa/XWayland.

In OpenGL mode the surface returned by `SDL_GetWindowSurface()` is only used
as a "not null" check anyway, so the fix is simply not to call it on a GL
window. I create the GL context first and use a tiny 1x1 dummy surface
instead:

```c
g_glcontext = SDL_GL_CreateContext(g_window);
g_screen = SDL_CreateRGBSurface(0, 1, 1, g_bpp, RMASK, GMASK, BMASK, AMASK);
```

Tested on Ubuntu 24.04 with SDL2 2.30: OpenGL renders correctly again, and
software rendering is unchanged. Only the SDL2 OpenGL path is touched.

Regards from France
